### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -171,8 +171,8 @@
             </div>
           </div>
         </div>
+        <% end %>
       </li>
-      <% end %>
     <% end %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,12 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% if @items.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +154,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% end %>
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -172,10 +171,9 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーの情報が0を選択していると保存ができないこと' do
         @item.category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 0")
+        expect(@item.errors.full_messages).to include('Category must be other than 0')
       end
       it '商品の状態についての情報が空だと保存ができないこと' do
         @item.status_id = ''
@@ -46,7 +46,7 @@ RSpec.describe Item, type: :model do
       it '商品の状態についての情報が0を選択していると保存ができないこと' do
         @item.status_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status must be other than 0")
+        expect(@item.errors.full_messages).to include('Status must be other than 0')
       end
       it '配送料の負担についての情報が空だと保存ができないこと' do
         @item.shipping_charge_id = ''
@@ -56,7 +56,7 @@ RSpec.describe Item, type: :model do
       it '配送料の負担についての情報が0を選択していると保存ができないこと' do
         @item.shipping_charge_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping charge must be other than 0")
+        expect(@item.errors.full_messages).to include('Shipping charge must be other than 0')
       end
       it '発送元の地域についての情報が空だと保存ができないこと' do
         @item.prefecture_id = ''
@@ -66,7 +66,7 @@ RSpec.describe Item, type: :model do
       it '発送元の地域についての情報が0を選択していると保存ができないこと' do
         @item.prefecture_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 0")
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 0')
       end
       it '発送までの日数についての情報が空だと保存ができないこと' do
         @item.days_to_ship_id = ''
@@ -76,7 +76,7 @@ RSpec.describe Item, type: :model do
       it '発送までの日数についての情報が0を選択していると保存ができないこと' do
         @item.days_to_ship_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Days to ship must be other than 0")
+        expect(@item.errors.full_messages).to include('Days to ship must be other than 0')
       end
       it '販売価格が空だと保存ができないこと' do
         @item.price = ''
@@ -89,7 +89,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it '販売価格が10000000円以上では保存できないこと' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# why
商品一覧を表示させるため

## Gyazo 「商品のデータがない場合は、ダミー商品が表示されている」
https://gyazo.com/a2b0e57cacf558ae571c9ee655214f61

## Gyazo 「商品のデータがある場合は、商品が一覧で表示されている」
https://gyazo.com/9a4175f078513814f761bf9e89f88d40
※2枚目の撮影時、キャプチャ撮影後にGyazoGIFが固まってしまい保存ができないため、画像のリンクを貼ります。

※商品購入機能はまだ未実装のため、soldoutの表示はまだ実装しておりません。よろしくお願いします。